### PR TITLE
Fix: failed scan background style not ends ';'

### DIFF
--- a/index.js
+++ b/index.js
@@ -552,7 +552,7 @@ function isBackgroundDecl(decl) {
  * @return {Boolean}
  */
 function hasImageInRule(rule) {
-	return /background[^:]*.*url[^;]+;/gi.test(rule);
+	return /background[^:]*.*url[^;]+/gi.test(rule);
 }
 
 /**


### PR DESCRIPTION
if a css rule:

  .foo {
    background: url('../images/arrow.png')
  }

The background style not ignored, because it is not end with ';'.
Not all css style end with ';' though.