### PR TITLE
Ensure an error is thrown on failure.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,12 @@ export default postcss.plugin('postcss-sprites', (opts = {}) => {
 			.spread((opts, images, spritesheets) => updateReferences(css, opts, images, spritesheets))
 			.spread((root, opts, images, spritesheets) => {
 				console.log(`postcss-sprites: ${spritesheets.length} ${spritesheets.length > 1 ? 'spritesheets' : 'spritesheet'} generated.`);
-			});
+			})
+      .catch((err) => {
+        console.error('An error occurred while processing files');
+        console.error(err);
+        throw new Error(err);
+      });
 	}
 });
 

--- a/test/12-examples.js
+++ b/test/12-examples.js
@@ -134,3 +134,16 @@ test('skip prefix', async (t) => {
 
 	return run(inputPath, expectedPath, opts, t);
 });
+
+test('throws error', async (t) => {
+  const inputPath = './fixtures/error/style.css';
+	const opts = {
+		stylesheetPath: './build/example-error/',
+		spritePath: './build/example-error/',
+  };
+  
+	const input = await fs.readFileAsync(inputPath, 'utf8');
+	const processor = postcss([plugin(opts)]);
+
+  t.throws(processor.process(input, { from: inputPath }));
+});

--- a/test/fixtures/error/style.css
+++ b/test/fixtures/error/style.css
@@ -1,0 +1,1 @@
+.selector-err { background-image: url(a.svg); }


### PR DESCRIPTION
In debugging the program I found that errors were being swallowed by
promises. This commit should report the error to the console and throw
it by attaching a catch to the main promise chain.

I also added a test to examples, not sure if it's the best place to put
it, open to recommendations.

More informaton can be found here:
https://github.com/2createStudio/postcss-sprites/issues/40