### PR TITLE
The padding is NaN in retina sprites

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -297,7 +297,7 @@ export function runSpritesmith(opts, images) {
 						.flatten('ratio')
 						.uniq()
 						.head()
-						.value();
+						.value().ratio;
 
 					if (ratio) {
 						config.padding = config.padding * ratio;


### PR DESCRIPTION
`_.chain(images).flatten('ratio').uniq().head().value()` return an Object ,  not a number 