### PR TITLE
the way to output dimensions of sprites in newest version has changed

### DIFF
--- a/examples/output-dimensions.md
+++ b/examples/output-dimensions.md
@@ -15,19 +15,19 @@ var updateRule = require('postcss-sprites').updateRule;
 var opts = {
 	stylesheetPath: './css',
 	spritePath: './css/images/',
-	hooks: {
-		onUpdateRule: function(rule, token, image) {
-			// Use built-in logic for background-image & background-position
-			updateRule(rule, token, image);
+    hooks: {
+        onUpdateRule: function(rule, token, image) {
+            // Use built-in logic for background-image & background-position
+            updateRule(rule, token, image);
 
-			['width', 'height'].forEach(function(prop) {
-				rule.insertAfter(rule.last, postcss.decl({
-					prop: prop,
-					value: image.coords[prop] + 'px'
-				}));
-			});
-		}
-	}
+            ['width', 'height'].forEach(function(prop) {
+                rule.insertAfter(rule.last, {
+                    prop: prop,
+                    value: image.coords[prop] + 'px'
+                });
+            });
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
in newest version, the example at 'examples/output-dimensions.md' couldn't work anymore, this id the correct way to output dimension