### PR TITLE
Fix 'getImageUrl' function

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -476,7 +476,7 @@ export function hasImageInRule(rule) {
  * @return {Array}
  */
 export function getImageUrl(rule) {
-	const matches = /background[^:]*:.*url\(([\S]+)\)/gi.exec(rule);
+	const matches = /url(?:\(['"]?)(.*?)(?:['"]?\))/gi.exec(rule);
 	let original = '';
 	let normalized = '';
 

--- a/test/02-utilities.js
+++ b/test/02-utilities.js
@@ -44,6 +44,16 @@ test('should return the url of an image', (t) => {
 	t.deepEqual(getImageUrl(backgroundColor)[1], '');
 });
 
+test('shoud return the url of an image in compressed CSS rules', (t) => {
+	const background = '.selector-a{background:url(square.png) no-repeat 0 0;transform:scale(0.5)}';
+	const backgroundImage = '.selector-a{background-image:url(square.png);transform:scale(0.5)}';
+	const backgroundColor = '.selector-a{background:#fff;transform:scale(0.5)}';
+
+	t.deepEqual(getImageUrl(background)[1], 'square.png');
+	t.deepEqual(getImageUrl(backgroundImage)[1], 'square.png');
+	t.deepEqual(getImageUrl(backgroundColor)[1], '');
+});
+
 test('should remove get params', (t) => {
 	const background = '.selector-b { background: url(square.png?v1234) no-repeat 0 0; }';
 	t.deepEqual(getImageUrl(background)[1], 'square.png');


### PR DESCRIPTION
Fix the problem that can not extracts the correct url of image from compressed CSS rule.

If there is another brackets after background rule, the `getImageUrl` function can't extract the correct url of image.

Input:
```css
.share-container .plane{width:75px;height:75px;background-image:url("../img/other/plane.png");background-repeat:no-repeat;-webkit-transform:scale(0.5);transform:scale(0.5);}
```

Output:
```
"../img/other/plane.png);background-repeat:no-repeat;-webkit-transform:scale(0.5);transform:scale(0.5"
```

Expect:
```
"../img/other/plane.png"
```