### PR TITLE
Extend onSaveSpritesheet parameters

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -331,7 +331,7 @@ export function saveSpritesheets(root, opts, images, spritesheets) {
 	return Promise.each(spritesheets, (spritesheet) => {
 		return (
 				_.isFunction(opts.hooks.onSaveSpritesheet) ?
-				Promise.resolve(opts.hooks.onSaveSpritesheet(root, opts, spritesheet)) :
+				Promise.resolve(opts.hooks.onSaveSpritesheet(opts, spritesheet, root)) :
 				Promise.resolve(makeSpritesheetPath(opts, spritesheet))
 			)
 			.then(( res ) => {

--- a/src/core.js
+++ b/src/core.js
@@ -321,16 +321,17 @@ export function runSpritesmith(opts, images) {
 
 /**
  * Saves the spritesheets to the disk.
+ * @param  {Node}   root
  * @param  {Object} opts
  * @param  {Array}  images
  * @param  {Array}  spritesheets
  * @return {Promise}
  */
-export function saveSpritesheets(css, opts, images, spritesheets) {
+export function saveSpritesheets(root, opts, images, spritesheets) {
 	return Promise.each(spritesheets, (spritesheet) => {
 		return (
 				_.isFunction(opts.hooks.onSaveSpritesheet) ?
-				Promise.resolve(opts.hooks.onSaveSpritesheet(css, opts, spritesheet)) :
+				Promise.resolve(opts.hooks.onSaveSpritesheet(root, opts, spritesheet)) :
 				Promise.resolve(makeSpritesheetPath(opts, spritesheet))
 			)
 			.then(( res ) => {

--- a/src/core.js
+++ b/src/core.js
@@ -326,7 +326,7 @@ export function runSpritesmith(opts, images) {
  * @param  {Array}  spritesheets
  * @return {Promise}
  */
-export function saveSpritesheets(opts, images, spritesheets) {
+export function saveSpritesheets(css, opts, images, spritesheets) {
 	return Promise.each(spritesheets, (spritesheet) => {
 		return (
 				_.isFunction(opts.hooks.onSaveSpritesheet) ?

--- a/src/core.js
+++ b/src/core.js
@@ -330,7 +330,7 @@ export function saveSpritesheets(css, opts, images, spritesheets) {
 	return Promise.each(spritesheets, (spritesheet) => {
 		return (
 				_.isFunction(opts.hooks.onSaveSpritesheet) ?
-				Promise.resolve(opts.hooks.onSaveSpritesheet(opts, spritesheet)) :
+				Promise.resolve(opts.hooks.onSaveSpritesheet(css, opts, spritesheet)) :
 				Promise.resolve(makeSpritesheetPath(opts, spritesheet))
 			)
 			.then(( res ) => {

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default postcss.plugin('postcss-sprites', (options = {}) => {
 			.spread((opts, images) => applyGroupBy(opts, images))
 			.spread((opts, images) => setTokens(css, opts, images))
 			.spread((root, opts, images) => runSpritesmith(opts, images))
-			.spread((opts, images, spritesheets) => saveSpritesheets(opts, images, spritesheets))
+			.spread((opts, images, spritesheets) => saveSpritesheets(css, opts, images, spritesheets))
 			.spread((opts, images, spritesheets) => mapSpritesheetProps(opts, images, spritesheets))
 			.spread((opts, images, spritesheets) => updateReferences(css, opts, images, spritesheets))
 			.spread((root, opts, images, spritesheets) => {

--- a/test/08-save-spritesheets.js
+++ b/test/08-save-spritesheets.js
@@ -22,13 +22,13 @@ test.beforeEach((t) => {
 test('should save spritesheets', async (t) => {
 	const cssContents = await readFileAsync('./fixtures/basic/style.css');
 	const ast = postcss.parse(cssContents, { from: './fixtures/basic/style.css' });
-	let images, spritesheets, opts;
+	let images, spritesheets, opts, root;
 
 	t.context.opts.spritePath = './build/basic';
 
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/basic/sprite.png');
 	t.truthy(fs.statAsync('./build/basic/sprite.png'));
@@ -37,7 +37,7 @@ test('should save spritesheets', async (t) => {
 test('should save SVG spritesheets', async (t) => {
 	const cssContents = await readFileAsync('./fixtures/svg-basic/style.css');
 	const ast = postcss.parse(cssContents, { from: './fixtures/svg-basic/style.css' });
-	let images, spritesheets, opts;
+	let images, spritesheets, opts, root;
 
 	t.context.opts.spritePath = './build/svg-basic';
 
@@ -45,7 +45,7 @@ test('should save SVG spritesheets', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images ] = await applyGroupBy(t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/svg-basic/sprite.svg');
 	t.truthy(fs.statAsync('./build/svg-basic/sprite.svg'));
@@ -54,7 +54,7 @@ test('should save SVG spritesheets', async (t) => {
 test('should save spritesheets by groups', async (t) => {
 	const cssContents = await readFileAsync('./fixtures/retina/style.css');
 	const ast = postcss.parse(cssContents, { from: './fixtures/retina/style.css' });
-	let images, spritesheets, opts;
+	let images, spritesheets, opts, root;
 
 	t.context.opts.spritePath = './build/retina';
 	t.context.opts.retina = true;
@@ -64,7 +64,7 @@ test('should save spritesheets by groups', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images ] = await applyGroupBy(t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/retina/sprite.png');
 	t.deepEqual(spritesheets[1].path, 'build/retina/sprite.@2x.png');
@@ -75,7 +75,7 @@ test('should save spritesheets by groups', async (t) => {
 test('should use path provided by book', async (t) => {
 	const cssContents = await readFileAsync('./fixtures/basic/style.css');
 	const ast = postcss.parse(cssContents, { from: './fixtures/basic/style.css' });
-	let images, spritesheets, opts;
+	let images, spritesheets, opts, root;
 
 	t.context.opts.spritePath = './build/on-save-hook/';
 	t.context.opts.hooks.onSaveSpritesheet = (pluginOpts, spritesheetGroups) => {
@@ -84,7 +84,7 @@ test('should use path provided by book', async (t) => {
 
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/on-save-hook/custom-name.png');
 	t.truthy(fs.statAsync('./build/on-save-hook/custom-name.png'));
@@ -109,7 +109,7 @@ test('should throw error if path is empty', async (t) => {
 test('should use Promise result provided by book', async (t) => {
 	const cssContents = await readFileAsync('./fixtures/basic/style.css');
 	const ast = postcss.parse(cssContents, { from: './fixtures/basic/style.css' });
-	let images, spritesheets, opts;
+	let images, spritesheets, opts, root;
 
 	t.context.opts.spritePath = './build/on-save-hook/';
 	t.context.opts.hooks.onSaveSpritesheet = (pluginOpts, spritesheetGroups) => {
@@ -118,7 +118,7 @@ test('should use Promise result provided by book', async (t) => {
 
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/on-save-hook/custom-name.png');
 	t.truthy(fs.statAsync('./build/on-save-hook/custom-name.png'));

--- a/test/08-save-spritesheets.js
+++ b/test/08-save-spritesheets.js
@@ -28,7 +28,7 @@ test('should save spritesheets', async (t) => {
 
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/basic/sprite.png');
 	t.truthy(fs.statAsync('./build/basic/sprite.png'));
@@ -45,7 +45,7 @@ test('should save SVG spritesheets', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images ] = await applyGroupBy(t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/svg-basic/sprite.svg');
 	t.truthy(fs.statAsync('./build/svg-basic/sprite.svg'));
@@ -64,7 +64,7 @@ test('should save spritesheets by groups', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images ] = await applyGroupBy(t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/retina/sprite.png');
 	t.deepEqual(spritesheets[1].path, 'build/retina/sprite.@2x.png');
@@ -84,7 +84,7 @@ test('should use path provided by book', async (t) => {
 
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/on-save-hook/custom-name.png');
 	t.truthy(fs.statAsync('./build/on-save-hook/custom-name.png'));
@@ -103,7 +103,7 @@ test('should throw error if path is empty', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
 
-	t.throws(saveSpritesheets(images, t.context.opts, spritesheets));
+	t.throws(saveSpritesheets(root, images, t.context.opts, spritesheets));
 });
 
 test('should use Promise result provided by book', async (t) => {
@@ -118,7 +118,7 @@ test('should use Promise result provided by book', async (t) => {
 
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ root, opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 
 	t.deepEqual(spritesheets[0].path, 'build/on-save-hook/custom-name.png');
 	t.truthy(fs.statAsync('./build/on-save-hook/custom-name.png'));

--- a/test/09-map-spritesheet-props.js
+++ b/test/09-map-spritesheet-props.js
@@ -28,7 +28,7 @@ test('should add coords & spritePath to every image', async (t) => {
 
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 	[ opts, images, spritesheets ] = await mapSpritesheetProps(t.context.opts, images, spritesheets);
 
 	t.deepEqual(images[0].spritePath, 'build/basic/sprite.png');
@@ -46,7 +46,7 @@ test('should add coords & spritePath to every SVG image', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ opts, images ] = await applyGroupBy(t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 	[ opts, images, spritesheets ] = await mapSpritesheetProps(t.context.opts, images, spritesheets);
 
 	t.deepEqual(images[0].spritePath, 'build/svg-basic/sprite.svg');

--- a/test/10-update-references.js
+++ b/test/10-update-references.js
@@ -32,7 +32,7 @@ test('should update CSS declarations', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ root, opts, images ] = await setTokens(ast, t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 	[ opts, images, spritesheets ] = await mapSpritesheetProps(t.context.opts, images, spritesheets);
 	[ root, opts, images, spritesheets ] = await updateReferences(root, t.context.opts, images, spritesheets);
 
@@ -50,7 +50,7 @@ test('should update CSS declarations with relative paths', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ root, opts, images ] = await setTokens(ast, t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 	[ opts, images, spritesheets ] = await mapSpritesheetProps(t.context.opts, images, spritesheets);
 	[ root, opts, images, spritesheets ] = await updateReferences(root, t.context.opts, images, spritesheets);
 
@@ -79,7 +79,7 @@ test('should use function provided by onUpdateRule hook', async (t) => {
 	[ opts, images ] = await extractImages(ast, t.context.opts);
 	[ root, opts, images ] = await setTokens(ast, t.context.opts, images);
 	[ opts, images, spritesheets ] = await runSpritesmith(t.context.opts, images);
-	[ opts, images, spritesheets ] = await saveSpritesheets(t.context.opts, images, spritesheets);
+	[ opts, images, spritesheets ] = await saveSpritesheets(root, t.context.opts, images, spritesheets);
 	[ opts, images, spritesheets ] = await mapSpritesheetProps(t.context.opts, images, spritesheets);
 	[ root, opts, images, spritesheets ] = await updateReferences(root, t.context.opts, images, spritesheets);
 


### PR DESCRIPTION
I add css as a parameter inside the onSaveSpritesheet hook in order to create the sprite files relative to the css files. Sadly, if I use the spritePath property, all sprite images will be placed and overwritten in the same directory.

But in my case:

_css/styles.css
img/build/sprite.png_

and in addition, the same structure for a campaign inside the project:

_campaign/css/style.css
campaign/img/build/sprite.png_

Adding the css parameter allows me to change the sprite file path. In that way postcss will add a separate sprite image for the base styles and also for the campaign styles. 

```
hooks: {
	onSaveSpritesheet: function(css, opts, spritesheet) {
		var
			path = css.source.input.file.match(/(.+?)\/css\//),
			file = ['sprite'].concat(spritesheet.groups, [spritesheet.extension]).join('.')
		;

		return path[1] + '/img/build/' + file;
	}
}
```

Or do you have a better solution to create sprites relative to the calling css file?